### PR TITLE
timeout=1, retries=1 breaks example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ Quickstart
     import raumfeld
 
     # discovery returns a list of RaumfeldDevices
-    devices = raumfeld.discover(timeout=1, retries=1)
+    devices = raumfeld.discover()
     if len(devices) > 0:
         speaker = devices[0]
 


### PR DESCRIPTION
Since timeout=1, retries=1 is defined in **init.py** it shouldn't be defined here (I think!)
